### PR TITLE
Bug that causes saves to fail

### DIFF
--- a/Terraria_Server/NetPlay.cs
+++ b/Terraria_Server/NetPlay.cs
@@ -249,7 +249,11 @@ namespace Terraria_Server
 				catch {}
 			}
 
-            WorldIO.saveWorld(Program.server.World.SavePath, true);
+			if (false == WorldIO.saveWorld(Program.server.World.SavePath, true))
+			{
+				WorldIO.saveWorld(Program.server.World.SavePath, true);
+				ProgramLog.Log("Saving failed.  Quitting without saving.");
+			}
 			
 			Statics.serverStarted = false;
 		}

--- a/Terraria_Server/WorldMod/WorldIO.cs
+++ b/Terraria_Server/WorldMod/WorldIO.cs
@@ -122,16 +122,18 @@ namespace Terraria_Server.WorldMod
 			worldCleared = true;
 		}
 
-		public static void saveWorld(String savePath, bool resetTime = false)
+		public static Boolean saveWorld(String savePath, bool resetTime = false)
 		{
+			Boolean success = true;
+
 			if (savePath == null)
 			{
-				return;
+				return false;
 			}
 
 			if (WorldModify.saveLock)
 			{
-				return;
+				return false;
 			}
 
 			try
@@ -335,13 +337,19 @@ namespace Terraria_Server.WorldMod
 					}
 					stopwatch.Stop();
 					ProgramLog.Log("Save duration: " + stopwatch.Elapsed.Seconds + " Second(s)");
-					WorldModify.saveLock = false;
 				}
 			}
 			catch (Exception e)
 			{
 				ProgramLog.Log(e, "Exception saving the world");
+				success = false;
 			}
+			finally
+			{
+				WorldModify.saveLock = false;
+			}
+
+			return success;
 		}
 
 		public static void loadWorld()


### PR DESCRIPTION
I found a fun bug with the way that saves work.  Whenever a save occurs, a lock gets set.  If the save fails, the lock is never removed.  Because if this, if there is ever any IO error during a save, no further saves can be performed.  For me, this was a random quicksave that failed in the middle of the night last night.  I only lost a day though.  Glad I restarted the server now.  :P

In addition to cleaning up the lock, this also makes the server attempt to save again if a save fails while shutting down.
