### PR TITLE
fixed invalid tile recieved from client error when placing new tiles

### DIFF
--- a/Terraria_Server/Messages/TileBreakMessage.cs
+++ b/Terraria_Server/Messages/TileBreakMessage.cs
@@ -45,7 +45,7 @@ namespace Terraria_Server.Messages
             switch (tileAction)
             {
                 case 1:
-                    if (tileType > 85)
+                    if (tileType > 105)
                     {
                         slot.Kick ("Invalid tile received from client.");
                         return;
@@ -59,7 +59,7 @@ namespace Terraria_Server.Messages
                     wall = true;
                     break;
                 case 3:
-                    if (tileType > 13)
+                    if (tileType > 20)
                     {
                         slot.Kick ("Invalid tile received from client.");
                         return;

--- a/Terraria_Server/Messages/TileSquareMessage.cs
+++ b/Terraria_Server/Messages/TileSquareMessage.cs
@@ -62,7 +62,7 @@ namespace Terraria_Server.Messages
                         int wasType = (int)tile.Type;
                         tile.Type = readBuffer[num++];
                         
-                        if (tile.Type > 85)
+                        if (tile.Type > 105)
                         {
                             slot.Kick ("Invalid tile received from client.");
                             return;
@@ -86,7 +86,7 @@ namespace Terraria_Server.Messages
                     {
                         tile.Wall = readBuffer[num++];
                         
-                        if (tile.Wall > 13)
+                        if (tile.Wall > 20)
                         {
                             slot.Kick ("Invalid tile received from client.");
                             return;


### PR DESCRIPTION
I only changed lines 50, 64 in TileBreakMessage.cs and lines 67, 91 in TileSquareMessage.cs .

Was I supposed to not click on convert line endings ?
