### PR TITLE
Possible refactoring error?

### DIFF
--- a/Terraria_Server/Collision.cs
+++ b/Terraria_Server/Collision.cs
@@ -767,7 +767,7 @@ namespace Terraria_Server
 							(float)Width <= vector.X || oldPosition.X >= vector.X + 16f || oldPosition.Y + 
 							(float)Height <= vector.Y || (double)oldPosition.Y >= (double)vector.Y + 16.01))
                         {
-                            WorldGen.hitSwitch(x, y);
+                            WorldGen.PlaceTraps();
                             NetMessage.SendData(59, -1, -1, "", x, (float)y, 0f, 0f, 0);
                             return true;
                         }


### PR DESCRIPTION
Not sure if this is what was supposed to happen or not, but it looks like it could be from the previous changes.

WorldGen.hitSwitch(x, y) => WorldGen.PlaceTraps()
