### PR TITLE
Invoke ServerState.LOADED after restarting by console command.

### DIFF
--- a/Terraria_Server/Commands/Commands.cs
+++ b/Terraria_Server/Commands/Commands.cs
@@ -1040,12 +1040,15 @@ namespace Terraria_Server.Commands
 			NetPlay.StopServer();
 			while (NetPlay.ServerUp) { Thread.Sleep(10); }
 
+            Statics.WorldLoaded = false;
+
 			ProgramLog.Log(Languages.StartingServer);
 			Main.Initialize();
 
 			Program.LoadPlugins();
 
 			WorldIO.LoadWorld(null, null, World.SavePath);
+
 			Program.updateThread = new ProgramThread("Updt", Program.UpdateLoop);
 			NetPlay.StartServer();
 
@@ -1053,7 +1056,7 @@ namespace Terraria_Server.Commands
 
             HookContext ctx = new HookContext
             {
-                Sender = World.Sender,
+                Sender = new ConsoleSender(),
             };
 
             HookArgs.ServerStateChange eArgs = new HookArgs.ServerStateChange


### PR DESCRIPTION
I wasn't sure if this is how you wanted this implemented, but if the intent of the LOADED serverstate is not just for the initial server loading, then this fixes the problem when using the restart command.
