### PR TITLE
fix for only earliest hook for PlayerEnteredGame invoked

### DIFF
--- a/Terraria_Server/NetMessage.cs
+++ b/Terraria_Server/NetMessage.cs
@@ -574,7 +574,7 @@ namespace Terraria_Server
 				Slot = plr,
 			};
 
-			ctx.SetResult(HookResult.DEFAULT);
+			ctx.SetResult(HookResult.DEFAULT, false);
 			HookPoints.PlayerEnteredGame.Invoke(ref ctx, ref args2);
 
 			if (ctx.CheckForKick())


### PR DESCRIPTION
You use the same context is being used for PlayerEnteringGame and PlayerEnteredGame, and you use SetResult to reset the context. But since SetResult sets the conclusion status implicitly (this might not be the best idea), only the first hook gets called in HookPoint<T>.Invoke().
