### PR TITLE
Give command allow string "max"

### DIFF
--- a/tdsm-core/Command/Commands.cs
+++ b/tdsm-core/Command/Commands.cs
@@ -591,7 +591,12 @@ namespace tdsm.core
         {
             // /give <player> <stack> <name> 
             Player receiver = args.GetOnlinePlayer(0);
-            int stack = args.GetInt(1);
+            string strStack = args.GetString(1);
+            if ( strStack.ToLower() = "max" ) {
+                int stack = Tools.AvailableItemSlots;
+            } else {
+                int stack = args.GetInt(1);
+            }
             string name = args.GetString(2);
 
             var max = Tools.AvailableItemSlots; //Perhaps remove a few incase of new drops


### PR DESCRIPTION
Allow the string "max" in place of an integer for the number of items wanted. This will allow the user to type for example; give max snowballs, to give all the possible snowballs the server can without having to be presented with a message saying how many can be spawned, and then typing the command once more with the new value.