### PR TITLE
allowed give to give max

### DIFF
--- a/tdsm-core/Command/Commands.cs
+++ b/tdsm-core/Command/Commands.cs
@@ -617,7 +617,7 @@ namespace tdsm.core
 
             var max = Tools.AvailableItemSlots; //Perhaps remove a few incase of new drops
             if (stack > max) {
-				stack = max;
+				stack = max; // Set to Tools.AvailableItemSlots because number given was larger than this.
 			}
             var results = DefinitionManager.FindItem(name);
             if (results != null && results.Length > 0)

--- a/tdsm-core/Command/Commands.cs
+++ b/tdsm-core/Command/Commands.cs
@@ -616,8 +616,9 @@ namespace tdsm.core
             string name = args.GetString(2);
 
             var max = Tools.AvailableItemSlots; //Perhaps remove a few incase of new drops
-            if (stack > max) throw new CommandError("Cannot give that many, available slots: {0}", max);
-
+            if (stack > max) {
+				stack = max;
+			}
             var results = DefinitionManager.FindItem(name);
             if (results != null && results.Length > 0)
             {


### PR DESCRIPTION
Give will now give Tools.AvailableItemSlots instead of what the user entered in the event the user entered more than Tools.AvailableItemSlots. This allows the command to go ahead and complete aith the max number of item slots available instead of just throwing an error and cancelling the command requiring the user to type it again with the number displayed.