### PR TITLE
Adding bash script as an alt to the Windows scripts (For Linux)

### DIFF
--- a/Binaries/start-server.sh
+++ b/Binaries/start-server.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+while true
+do
+	mono tdsm.exe -config server.config
+	echo "Restarting server..."
+	sleep 1
+done


### PR DESCRIPTION
This adds a simple bash script that's equivalent to the current .bat and .cmd scripts. It should work on all Linux distros, but requires mono since TDSM does to run on Linux.
